### PR TITLE
Add curl to linux install guide and ubuntu 20.04 to linux install guide

### DIFF
--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -13,7 +13,7 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Install the following prerequisites:
 
-		sudo apt-get install fakeroot git perl unzip build-essential libtinfo5
+		sudo apt-get install fakeroot git perl unzip build-essential libtinfo5 curl
 
 	<sup>
 	<sup>*</sup> build-essential and libtinfo5 or the equivalents for your distro.
@@ -48,7 +48,7 @@ All the commands shown in the following instructions are meant to be run as the 
 		mv $TMP/ios-arm64e-clang-toolchain/* $THEOS/toolchain/linux/iphone/
 		rm -r linux-ios-arm64e-clang-toolchain.tar.lzma $TMP
 
-	With Swift support (larger toolchain size):
+	With Swift support (ubuntu 18.04, larger toolchain size):
 
 		sudo apt install zstd
 		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu18.04.tar.zst
@@ -58,6 +58,17 @@ All the commands shown in the following instructions are meant to be run as the 
 		mv $TMP/swift-5.3.2-RELEASE-ubuntu18.04/* $THEOS/toolchain/linux/iphone/
 		ln -s $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
 		rm -r swift-5.3.2-RELEASE-ubuntu18.04.tar.zst $TMP
+
+	With Swift support (ubuntu 20.04, larger toolchain size):
+
+		sudo apt install zstd
+		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu20.04.tar.zst
+		TMP=$(mktemp -d)
+		tar -xvf swift-5.3.2-RELEASE-ubuntu20.04.tar.zst -C $TMP
+		mkdir -p $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
+		mv $TMP/swift-5.3.2-RELEASE-ubuntu20.04/* $THEOS/toolchain/linux/iphone/
+		ln -s $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
+		rm -r swift-5.3.2-RELEASE-ubuntu20.04.tar.zst $TMP
 
 	Note that compiling Swift code requires a fairly modern SDK. It is recommended that you use the latest SDK that you can get.
 

--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -13,7 +13,7 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Install the following prerequisites:
 
-		sudo apt-get install fakeroot git perl unzip build-essential libtinfo5 curl
+		sudo apt-get install fakeroot git perl unzip build-essential libtinfo5 curl libz3-dev
 
 	<sup>
 	<sup>*</sup> build-essential and libtinfo5 or the equivalents for your distro.
@@ -48,18 +48,7 @@ All the commands shown in the following instructions are meant to be run as the 
 		mv $TMP/ios-arm64e-clang-toolchain/* $THEOS/toolchain/linux/iphone/
 		rm -r linux-ios-arm64e-clang-toolchain.tar.lzma $TMP
 
-	With Swift support (ubuntu 18.04, larger toolchain size):
-
-		sudo apt install zstd
-		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu18.04.tar.zst
-		TMP=$(mktemp -d)
-		tar -xvf swift-5.3.2-RELEASE-ubuntu18.04.tar.zst -C $TMP
-		mkdir -p $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		mv $TMP/swift-5.3.2-RELEASE-ubuntu18.04/* $THEOS/toolchain/linux/iphone/
-		ln -s $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		rm -r swift-5.3.2-RELEASE-ubuntu18.04.tar.zst $TMP
-
-	With Swift support (ubuntu 20.04, larger toolchain size):
+	With Swift support (larger toolchain size):
 
 		sudo apt install zstd
 		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu20.04.tar.zst


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It adds curl to the default install list cause curl isn't always installed on some linux distros (especially ones based off ubuntu 20.04+)

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Hi Kirb 👋 

Where has this been tested?
---------------------------
Is this needed for docs update stuff? Anyways, ubuntu 20.04 and linux mint 20.4