### PR TITLE
Update iOS install instructions 

### DIFF
--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -13,9 +13,9 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Install the following prerequisites:
 
-	* If your jailbreak uses **Procursus**, ensure that you have the [Procursus repo](https://apt.procurs.us/) installed in your package manager of choice and then install the `Theos Dependencies` package from it (*not* the one available on BigBoss)
-
 	* If your jailbreak uses **Elucubratus**, ensure that you have the [Elucubratus repo](https://apt.bingner.com) installed in your package manager of choice and then install `ca-certificates`, `clang`, `coreutils`, `curl`, `dpkg`, `git`, `grep`, `ldid`, `make`, `odcctools`, `perl`, `com.bingner.plutil`, `rsync`, `unzip`, and `xz` from it if they're not installed already (*not* the packages available on BigBoss)
+
+	* If your jailbreak uses **Procursus**, ensure that you have the [Procursus repo](https://apt.procurs.us/) installed in your package manager of choice and then install the `Theos Dependencies` package from it (*not* the one available on BigBoss)
 
 	* If your jailbreak uses **Telesphoreo**, ensure that you have [Sam Bingner’s repo](http://repo.bingner.com/) installed in your package manager of choice and then install the `Theos Dependencies` package from BigBoss
 
@@ -27,20 +27,14 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Set up the `THEOS` environment variable:
 
+	**Note**: if your device is jailbroken with checkra1n, replace "~/theos" in the command below with "/opt/theos"
+
 	bash:
 
-		# If running checkra1n
-		echo "export THEOS=/opt/theos" >> ~/.profile
-
-		# Else
 		echo "export THEOS=~/theos" >> ~/.profile
 
 	zsh:
 
-		# If running checkra1n
-		echo "export THEOS=/opt/theos" >> ~/.zshenv
-
-		# Else
 		echo "export THEOS=~/theos" >> ~/.zshenv
 
 	For this change to take effect, you must restart your shell. Kill the terminal app in the taskswitcher then re-open the terminal app and do `echo $THEOS` on your shell to check if this is working.

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -13,17 +13,34 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Install the following prerequisites:
 
-	* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repository](http://repo.bingner.com/)
-	* Theos Dependencies (package on either the Procursus or BigBoss repo, relies on the previous repository being installed first)
+	* If your jailbreak uses **Procursus**, ensure that you have the [Procursus repo](https://apt.procurs.us/) installed in your package manager of choice and then install the `Theos Dependencies` package from it (*not* the one available on BigBoss)
+
+	* If your jailbreak uses **Elucubratus**, ensure that you have the [Elucubratus repo](https://apt.bingner.com) installed in your package manager of choice and then install `ca-certificates`, `clang`, `coreutils`, `curl`, `dpkg`, `git`, `grep`, `ldid`, `make`, `odcctools`, `perl`, `com.bingner.plutil`, `rsync`, `unzip`, and `xz` from it if they're not installed already (*not* the packages available on BigBoss)
+
+	* If your jailbreak uses **Telesphoreo**, ensure that you have [Sam Bingner’s repo](http://repo.bingner.com/) installed in your package manager of choice and then install the `Theos Dependencies` package from BigBoss
+
+1. If your device is jailbroken with [checkra1n](https://checkra.in/), run the following commands to create a directory to house Theos:
+
+		su
+		install -d -o mobile -g mobile /opt
+		exit
 
 1. Set up the `THEOS` environment variable:
 
 	bash:
 
+		# If running checkra1n
+		echo "export THEOS=/opt/theos" >> ~/.profile
+
+		# Else
 		echo "export THEOS=~/theos" >> ~/.profile
 
 	zsh:
 
+		# If running checkra1n
+		echo "export THEOS=/opt/theos" >> ~/.zshenv
+
+		# Else
 		echo "export THEOS=~/theos" >> ~/.zshenv
 
 	For this change to take effect, you must restart your shell. Kill the terminal app in the taskswitcher then re-open the terminal app and do `echo $THEOS` on your shell to check if this is working.

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -13,11 +13,11 @@ All the commands shown in the following instructions are meant to be run as the 
 
 1. Install the following prerequisites:
 
-	* If your jailbreak uses **Elucubratus**, ensure that you have the [Elucubratus repo](https://apt.bingner.com) installed in your package manager of choice and then install `ca-certificates`, `clang`, `coreutils`, `curl`, `dpkg`, `git`, `grep`, `ldid`, `make`, `odcctools`, `perl`, `com.bingner.plutil`, `rsync`, `unzip`, and `xz` from it if they're not installed already (*not* the packages available on BigBoss)
+	* If your jailbreak uses **Elucubratus**, ensure that you have the [Elucubratus repo](https://apt.bingner.com) installed in your package manager of choice and then install `clang`, `curl`, `git`, `grep`, `ldid`, `make`, `odcctools`, `perl`, `com.bingner.plutil`, `rsync`, `unzip`, and `xz` from it if they're not installed already (*not* the packages available on BigBoss)
 
-	* If your jailbreak uses **Procursus**, ensure that you have the [Procursus repo](https://apt.procurs.us/) installed in your package manager of choice and then install the `Theos Dependencies` package from it (*not* the one available on BigBoss)
+	* If your jailbreak uses **Procursus**, ensure that you have the [Procursus repo](https://apt.procurs.us/) installed in your package manager of choice and then install the `Theos Dependencies` and `plutil` packages from it (*not* the packages available on BigBoss)
 
-	* If your jailbreak uses **Telesphoreo**, ensure that you have [Sam Bingner’s repo](http://repo.bingner.com/) installed in your package manager of choice and then install the `Theos Dependencies` package from BigBoss
+	* If your jailbreak uses **Telesphoreo**, ensure that you have [Sam Bingner’s repo](http://repo.bingner.com/) and [Coolstar's public repo](https://coolstar.org/publicrepo/) installed in your package manager of choice and then install the `Theos Dependencies` package from BigBoss
 
 1. If your device is jailbroken with [checkra1n](https://checkra.in/), run the following commands to create a directory to house Theos:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Updates the iOS install instructions to specify the necessary packages for Elucubratus 
  - This is meant to prevent people from installing the outdated dependencies package on BigBoss (see: [theos#616](https://github.com/theos/theos/issues/616)) which would otherwise result in unknown arch and/or undefined symbol errors upon running `make`
- Adds specific instructions for users jailbroken with checkra1n (to install to /opt/ instead of /var/mobile/)
  - This is meant to prevent people from installing Theos in a directory that doesn't allow exec which would otherwise result in a ```killed: 9``` error when any of the perl scripts attempt to run

Does this close any currently open issues?
------------------------------------------
Nope

Any relevant logs, error output, etc?
-------------------------------------
Re Elucubratus dependencies: [https://github.com/theos/theos/issues/559](https://github.com/theos/theos/issues/559)
Re ```killed: 9```: [https://github.com/theos/theos/issues/460](https://github.com/theos/theos/issues/460)

Any other comments?
-------------------
Once Theos Dependencies package is updated and not bootstrap-specific, the Elucubratus and Procursus specific instructions can be merged and simplified. 

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
