### PR TITLE
Update Swift toolchain download link

### DIFF
--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -46,14 +46,8 @@ All the commands shown in the following instructions are meant to be run as a no
 
 	With Swift support (larger toolchain size):
 
-		sudo apt install zstd
-		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu20.04.tar.zst
-		TMP=$(mktemp -d)
-		tar -xvf swift-5.3.2-RELEASE-ubuntu20.04.tar.zst -C $TMP
-		mkdir -p $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		mv $TMP/swift-5.3.2-RELEASE-ubuntu20.04/* $THEOS/toolchain/linux/iphone/
-		ln -s $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		rm -r swift-5.3.2-RELEASE-ubuntu20.04.tar.zst $TMP
+		curl -#L https://github.com/kabiroberai/swift-toolchain-linux/releases/download/v2.1.0/swift-5.6.1-ubuntu20.04.tar.xz \
+		  | tar -xvJ -C $THEOS/toolchain
 
 	Note that compiling Swift code requires a fairly modern SDK. It is recommended that you use the latest SDK that you can get.
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR updates the Swift toolchain link to a newer toolchain, compatible with Swift 5.6 (vis-a-vis the previous 5.3 toolchain).


Where has this been tested?
---------------------------
**Operating System:** Ubuntu 20.04 (aarch64, but I've linked the x64 version in the docs.)

**Platform:** Linux

**Target Platform:** iOS

**Toolchain Version:** Cutting-edge :)

**SDK Version:** iOS 15.5
