### PR TITLE
Update the install instructions to use `install-theos` 

### DIFF
--- a/docs/Installation-Cygwin.md
+++ b/docs/Installation-Cygwin.md
@@ -15,7 +15,7 @@ This guide will help you install Theos on your Windows machine via Cygwin.
 Please note that the latest toolchain provided for Cygwin only supports iOS SDKs earlier than iOS 11. For 32-bit installations of Cygwin, this is more severely limited to iOS SDKs earlier than iOS 8, and lacks support for building arm64 binaries.
 </div>
 
-All the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+All of the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is meant to be run as a normal user, _not_ root.
 
 1. Install the following prerequisites:
 

--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -9,7 +9,7 @@ This guide will help you install Theos on your Linux machine, Windows machine vi
 |----------|--------------------|-------------------|
 | **Linux** <br> **Windows 10** | Linux kernel 3.16 <br> Windows 10 build 14393 | Linux, iOS |
 
-Unless otherwise stated, all the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+Unless otherwise stated, all of the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is meant to be run as a normal user, _not_ root.
 
 1. If you are running on Windows and haven’t already installed a Linux distribution, follow [Microsoft’s instructions](https://aka.ms/wslinstall) to do so.
 

--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -9,60 +9,32 @@ This guide will help you install Theos on your Linux machine, Windows machine vi
 |----------|--------------------|-------------------|
 | **Linux** <br> **Windows 10** | Linux kernel 3.16 <br> Windows 10 build 14393 | Linux, iOS |
 
-All the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+Unless otherwise stated, all the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
 
 1. If you are running on Windows and haven’t already installed a Linux distribution, follow [Microsoft’s instructions](https://aka.ms/wslinstall) to do so.
 
-1. Install the following prerequisites:
+1. Install the following prerequisites<sup>1</sup> as *root*:
 
-		sudo apt install build-essential fakeroot libtinfo5 libz3-dev rsync curl perl unzip git
+	- Debian-based distros
 
-	If you don’t use a distribution that uses the APT package manager such as Debian, Ubuntu, Linux Mint, or Pop!_OS, you will need to determine the equivalent packages to install from your distribution’s package manager.
+			apt install bash curl sudo
 
-1. If you are running on Windows using WSL 1 ([how do I know?](https://aka.ms/wslinstall#check-which-version-of-wsl-you-are-running)), apply the following fix so `fakeroot` works:
+	- Arch-based distros
 
-		sudo update-alternatives --set fakeroot /usr/bin/fakeroot-tcp
+			pacman -S --needed bash curl sudo
 
-1. Set up the `THEOS` environment variable:
+	- Redhat-based distros
 
-		echo "export THEOS=~/theos" >> ~/.profile
+			dnf install bash curl sudo
 
-	For this change to take effect, you must restart your shell. Open a new tab and do `echo $THEOS` on your shell to check if this is working.
+	- SUSE-based distros
 
-1. Clone Theos to your device:
+			zypper install bash curl sudo
 
-		git clone --recursive https://github.com/theos/theos.git $THEOS
+	<sup>
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
+	</sup>
 
-1. Get a toolchain:
+1. Run the installer:
 
-	Without Swift support (smaller toolchain size):
-
-		curl -LO https://github.com/sbingner/llvm-project/releases/latest/download/linux-ios-arm64e-clang-toolchain.tar.lzma
-		TMP=$(mktemp -d)
-		tar -xvf linux-ios-arm64e-clang-toolchain.tar.lzma -C $TMP
-		mkdir -p $THEOS/toolchain/linux/iphone
-		mv $TMP/ios-arm64e-clang-toolchain/* $THEOS/toolchain/linux/iphone/
-		rm -r linux-ios-arm64e-clang-toolchain.tar.lzma $TMP
-
-	With Swift support (larger toolchain size):
-
-		sudo apt install zstd
-		curl -LO https://github.com/CRKatri/llvm-project/releases/download/swift-5.3.2-RELEASE/swift-5.3.2-RELEASE-ubuntu20.04.tar.zst
-		TMP=$(mktemp -d)
-		tar -xvf swift-5.3.2-RELEASE-ubuntu20.04.tar.zst -C $TMP
-		mkdir -p $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		mv $TMP/swift-5.3.2-RELEASE-ubuntu20.04/* $THEOS/toolchain/linux/iphone/
-		ln -s $THEOS/toolchain/linux/iphone $THEOS/toolchain/swift
-		rm -r swift-5.3.2-RELEASE-ubuntu20.04.tar.zst $TMP
-
-	Note that compiling Swift code requires a fairly modern SDK. It is recommended that you use the latest SDK that you can get.
-
-1. Get an iOS SDK:
-
-	You can get patched SDKs from [our SDKs repo](https://github.com/theos/sdks).
-
-		curl -LO https://github.com/theos/sdks/archive/master.zip
-		TMP=$(mktemp -d)
-		unzip master.zip -d $TMP
-		mv $TMP/sdks-master/*.sdk $THEOS/sdks
-		rm -r master.zip $TMP
+		bash -c "$(curl -fsSL https://raw.githubusercontent.com/theos/theos/master/bin/install-theos)"

--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -32,7 +32,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 			zypper install bash curl sudo
 
 	<sup>
-	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see [here](https://wiki.archlinux.org/title/Sudo#Example_entries).
 	</sup>
 
 1. Run the installer:

--- a/docs/Installation-Linux.md
+++ b/docs/Installation-Linux.md
@@ -32,7 +32,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 			zypper install bash curl sudo
 
 	<sup>
-	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see [here](https://wiki.archlinux.org/title/Sudo#Example_entries).
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
 	</sup>
 
 1. Run the installer:

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -14,7 +14,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 1. Check that you have the necessary repos installed in your package manager:
 
 	* iOS >= 12.0
-		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repo](https://apt.bingner.com/) (this depends on the jailbreak you are using)
+		* [Procursus](https://apt.procurs.us/) or [Bingner/Elucubratus](https://apt.bingner.com/) (this depends on the jailbreak you are using)
 	* iOS < 12.0
 		* [Coolstar's repo](https://coolstar.org/publicrepo/), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
 

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -9,7 +9,7 @@ This guide will help you install Theos on your jailbroken iOS device.
 |----------|--------------------|-------------------|
 | **iOS** | 5.0 | iOS |
 
-Unless otherwise stated, all the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+Unless otherwise stated, all of the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is meant to be run as a normal user, _not_ root.
 
 1. Check that you have the necessary repos installed in your package manager:
 

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -9,45 +9,23 @@ This guide will help you install Theos on your jailbroken iOS device.
 |----------|--------------------|-------------------|
 | **iOS** | 5.0 | iOS |
 
-All the commands shown in the following instructions are meant to be run as the "mobile" user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+Unless otherwise stated, all the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
 
-1. Install the following prerequisites:
+1. Check that you have the necessary repos installed in your package manager:
 
-	* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repository](http://repo.bingner.com/)
-	* Theos Dependencies (package on either the Procursus or BigBoss repo, relies on the previous repository being installed first)
+	* iOS >= 12.0
+		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repository](http://repo.bingner.com/) (this depends on the jailbreak you are using)
+	* iOS < 12.0
+		* [Coolstar's repo](https://coolstar.org/publicrepo/'), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
 
-1. Set up the `THEOS` environment variable:
+1. Install the following prerequisites<sup>1</sup> as *root*:
 
-	bash:
+		apt-get install bash curl sudo
 
-		echo "export THEOS=~/theos" >> ~/.profile
+	<sup>
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
+	</sup>
 
-	zsh:
+1. Run the installer:
 
-		echo "export THEOS=~/theos" >> ~/.zshenv
-
-	For this change to take effect, you must restart your shell. Kill the terminal app in the taskswitcher then re-open the terminal app and do `echo $THEOS` on your shell to check if this is working.
-
-1. Clone Theos to your device:
-
-		git clone --recursive https://github.com/theos/theos.git $THEOS
-
-1. Get the toolchain:
-
-	Theos Dependencies installs iOS Toolchain.
-
-1. Get an iOS SDK:
-
-	You can get patched SDKs from [our SDKs repo](https://github.com/theos/sdks).
-
-		curl -LO https://github.com/theos/sdks/archive/master.zip
-		TMP=$(mktemp -d)
-		unzip master.zip -d $TMP
-		mv $TMP/sdks-master/*.sdk $THEOS/sdks
-		rm -r master.zip $TMP
-
-1. Install the Swift toolchain (optional):
-
-	Install `swift` if using Procursus, else install `swift-toolchain` from the BigBoss repo.
-
-	Note that compiling Swift code requires a fairly modern SDK. It is recommended that you use the latest SDK that you can get.
+		bash -c "$(curl -fsSL https://raw.githubusercontent.com/theos/theos/master/bin/install-theos)"

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -16,7 +16,7 @@ Unless otherwise stated, all the commands shown in the following instructions ar
 	* iOS >= 12.0
 		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repo](https://apt.bingner.com/) (this depends on the jailbreak you are using)
 	* iOS < 12.0
-		* [Coolstar's repo](https://coolstar.org/publicrepo/'), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
+		* [Coolstar's repo](https://coolstar.org/publicrepo/), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
 
 1. Install the following prerequisites<sup>1</sup> as *root*:
 

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -23,7 +23,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 		apt-get install bash curl sudo
 
 	<sup>
-	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see [here](https://wiki.archlinux.org/title/Sudo#Example_entries).
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
 	</sup>
 
 1. Run the installer:

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -14,7 +14,7 @@ Unless otherwise stated, all the commands shown in the following instructions ar
 1. Check that you have the necessary repos installed in your package manager:
 
 	* iOS >= 12.0
-		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repo](http://repo.bingner.com/) (this depends on the jailbreak you are using)
+		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repo](https://apt.bingner.com/) (this depends on the jailbreak you are using)
 	* iOS < 12.0
 		* [Coolstar's repo](https://coolstar.org/publicrepo/'), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
 

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -23,7 +23,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 		apt-get install bash curl sudo
 
 	<sup>
-	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see <a href=https://wiki.archlinux.org/title/Sudo#Example_entries>here</a>.
+	<sup>1</sup> In order to use <i>sudo</i>, your non-root user will have to be added to the sudoers file (/etc/sudoers). For more information, see [here](https://wiki.archlinux.org/title/Sudo#Example_entries).
 	</sup>
 
 1. Run the installer:

--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -14,7 +14,7 @@ Unless otherwise stated, all the commands shown in the following instructions ar
 1. Check that you have the necessary repos installed in your package manager:
 
 	* iOS >= 12.0
-		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repository](http://repo.bingner.com/) (this depends on the jailbreak you are using)
+		* [Procursus](https://apt.procurs.us/) or [Sam Bingner’s repo](http://repo.bingner.com/) (this depends on the jailbreak you are using)
 	* iOS < 12.0
 		* [Coolstar's repo](https://coolstar.org/publicrepo/'), [Sam Bingner's repo](https://repo.bingner.com/), and [BigBoss](http://apt.thebigboss.org/repofiles/cydia/)
 

--- a/docs/Installation-macOS.md
+++ b/docs/Installation-macOS.md
@@ -9,7 +9,7 @@ This guide will help you install Theos on your macOS device.
 |----------|--------------------|-------------------|
 | **macOS** | Mavericks (10.9) | macOS, iOS, watchOS, tvOS, and simulators |
 
-All the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+All of the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is meant to be run as a normal user, _not_ root.
 
 1. Install the following prerequisites:
 

--- a/docs/Installation-macOS.md
+++ b/docs/Installation-macOS.md
@@ -14,36 +14,14 @@ All the commands shown in the following instructions are meant to be run as a no
 1. Install the following prerequisites:
 
 	* [Homebrew](https://brew.sh/)
+		* or [MacPorts](https://www.macports.org/install.php)
+		* or Procursus Strap
 	* [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12)<sup>1</sup> is mandatory. The Command Line Tools package isn’t sufficient for Theos to work. Xcode includes toolchains for all Apple platforms.
 
 	<sup>
 	<sup>1</sup> Xcode 5.0 or newer. Xcode 4.4 supported, but only when building for ARMv6 (1st/2nd generation iPhone/iPod touch).
 	</sup>
 
-		brew install ldid xz
+1. Run the installer:
 
-1. Set up the `THEOS` environment variable:
-
-		echo "export THEOS=~/theos" >> ~/.zprofile
-
-    If you are using macOS 10.14 or older, change `~/.zprofile ` to `~/.profile`. The default shell was changed from bash to zsh in macOS 10.15. You can check which one you are using by running `echo $SHELL`.
-
-	For this change to take effect, you must restart your shell. Open a new tab and do `echo $THEOS` on your shell to check if this is working.
-
-1. Clone Theos to your device:
-
-		git clone --recursive https://github.com/theos/theos.git $THEOS
-
-1. Get the toolchain:
-
-	Xcode contains the toolchain.
-
-1. Get an iOS SDK:
-
-	Xcode always provides the latest iOS SDK, but as of Xcode 7.3, it no longer includes private frameworks you can link against. This may be an issue when developing tweaks. You can get patched SDKs from [our SDKs repo](https://github.com/theos/sdks).
-
-		curl -LO https://github.com/theos/sdks/archive/master.zip
-		TMP=$(mktemp -d)
-		unzip master.zip -d $TMP
-		mv $TMP/sdks-master/*.sdk $THEOS/sdks
-		rm -r master.zip $TMP
+		bash -c "$(curl -fsSL https://raw.githubusercontent.com/theos/theos/master/bin/install-theos)"

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,7 +6,7 @@ layout: docs
 ## Officially supported platforms
 Theos aims to work on, and build for, the following platforms.
 
-**Note**: Theos is meant to be installed as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+**Note**: Theos is meant to be installed as a normal user, _not_ root. Similarly, Theos is meant to be run as a normal user, _not_ root.
 
 - **[iOS](/docs/Installation-iOS.html)** on iOS 5 and up.
 - **[macOS](/docs/Installation-macOS.html)** on Mavericks (10.9) and up.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,7 +6,7 @@ layout: docs
 ## Officially supported platforms
 Theos aims to work on, and build for, the following platforms.
 
-**Note**: Theos is meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+**Note**: Theos is meant to be installed as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
 
 - **[iOS](/docs/Installation-iOS.html)** on iOS 5 and up.
 - **[macOS](/docs/Installation-macOS.html)** on Mavericks (10.9) and up.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,7 +6,7 @@ layout: docs
 ## Officially supported platforms
 Theos aims to work on, and build for, the following platforms.
 
-All the commands shown in the following instructions are meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
+**Note**: Theos is meant to be run as a normal user, _not_ root. Similarly, Theos is also meant to be run as a normal user, _not_ root.
 
 - **[iOS](/docs/Installation-iOS.html)** on iOS 5 and up.
 - **[macOS](/docs/Installation-macOS.html)** on Mavericks (10.9) and up.

--- a/docs/Swift.md
+++ b/docs/Swift.md
@@ -3,10 +3,10 @@ title: Swift
 layout: docs
 ---
 
-Theos is capable of compiling [Swift](https://swift.org/) files, and supports using them in conjunction with files written in other languages, such as Objective-C. These capabilities are supported on macOS, iOS, and Linux. Instructions for installing the Swift toolchains on [iOS](/docs/Installation-iOS.html) and [Linux](/docs/Installation-Linux.html) can be found on their respective installation wiki pages.
+Theos is capable of compiling [Swift](https://swift.org/) files, and supports using them in conjunction with files written in other languages, such as Objective-C. These capabilities are supported on macOS, iOS, and Linux.
 
 ## Swift Runtime
-In order to run Swift binaries built with Theos, you must install the Swift runtime on your iOS device. Currently, the runtime can be found on BigBoss under the `org.swift.libswift` package (Swift 5+) or the `com.modmyi.libswift4` package (Swift 4). It is recommended that you add libswift as a dependency in your control file with `Depends: ${LIBSWIFT}` as this will automatically select the correct package based on your Swift version.
+In order to run Swift binaries built with Theos, you must have the Swift runtime installed on your iOS device. Currently, the runtime can be found on BigBoss under the `org.swift.libswift` package (Swift 5+) or the `com.modmyi.libswift4` package (Swift 4). It is recommended that you add libswift as a dependency in your control file with `Depends: ${LIBSWIFT}` as this will automatically select the correct package based on your Swift version.
 
 ## Interoperability with Objective-C
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
No, but it will supersede #20

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
It's probably a good idea to check the installer on all platforms once more before this is merged. I tested it as I made changes and Uroboro ran it through additional VM tests, but a third once over wouldn't hurt. 

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
