### PR TITLE
Create dm.pl.md and NIC-Syntax.md

### DIFF
--- a/_data/docs_sidebar.yaml
+++ b/_data/docs_sidebar.yaml
@@ -23,6 +23,8 @@
   list:
     - title: NIC
       link: /docs/NIC.html
+    - title: NIC Syntax
+      link: /docs/NIC-Syntax.html
     - title: dm.pl
       link: /docs/dm.pl.html
     - title: Swift

--- a/_data/docs_sidebar.yaml
+++ b/_data/docs_sidebar.yaml
@@ -12,7 +12,7 @@
       link: /docs/Installation-Linux.html
     - title: Upgrading from legacy Theos
       link: /docs/Upgrading-from-legacy-Theos.html
-      
+
 - title: Usage
   list:
     - title: Commands
@@ -23,6 +23,8 @@
   list:
     - title: NIC
       link: /docs/NIC.html
+    - title: dm.pl
+      link: /docs/dm.pl.html
     - title: Swift
       link: /docs/Swift.html
 

--- a/css/NIC-Syntax.css
+++ b/css/NIC-Syntax.css
@@ -1,0 +1,60 @@
+body strong {
+	font-weight: 600;
+}
+
+code {
+	font-size: 10pt;
+	margin: .15em;
+	padding: .15em;
+	color: black;
+	background-color: #dddddd;
+	border: 1px solid #bbbbbb;
+	border-radius: 5px;
+	-webkit-border-radius: 5px;
+}
+
+code strong {
+	font-weight: 700;
+}
+
+code span.required, code span.optional {
+	font-size: 10pt !important;
+}
+
+span.required, span.optional {
+	padding-left: .4em;
+	padding-right: .4em;
+	font-size: 9pt;
+	border-radius: 10px;
+	-webkit-border-radius: 10px;
+	border: 1px solid;
+}
+
+span.required {
+	background-color: #ffcccc;
+	border-color: #cc0000;
+	font-weight: bold;
+	color: black;
+}
+
+span.optional {
+	background-color: #ffffcc;
+	border-color: #dddd00;
+	font-style: italic;
+	color: black;
+}
+
+code span.comment {
+	font-weight: bold;
+	color: #00007f;
+}
+
+code span.string {
+	font-weight: bold;
+	color: #7f0000;
+}
+
+code span.variable {
+	font-weight: bold;
+	color: #007f00;
+}

--- a/docs/NIC-Syntax.md
+++ b/docs/NIC-Syntax.md
@@ -128,7 +128,9 @@ The <code>NIC</code> object represents the current template.
 
 - <code class="method">NIC->prompt(<span class="required">$variable</span>, <span class="required">$prompt_text</span> <span class="optional">, {default => $default_value}</span>)</code>
     - *method*
-    - Prompt the user for additional information, attaching the user's response to the provided NIC variable. The default value is optional. If *$variable* is not specified, <code>NIC->prompt(...)</code> will return the user's response, and will not store it in the template.
+    - Prompt the user for additional information, attaching the user's response to the provided NIC variable.
+    - The default value is optional.
+    - If *$variable* is not specified, <code>NIC->prompt(...)</code> will return the user's response, and will not store it in the template.
     - The key difference between <code>prompt(...)</code> and <code>NIC->prompt(...)</code> is that the user is given a chance to override the prompt variable with his or her <code>~/.nicrc</code>.
 
 - <code class="method">NIC->setConstraint(<span class="required">$constraint</span>)</code>

--- a/docs/NIC-Syntax.md
+++ b/docs/NIC-Syntax.md
@@ -1,0 +1,222 @@
+---
+title: "NIC: Syntax"
+layout: docs
+---
+
+<!-- Dustin did heavy lifting with the styling work, so let's use that -->
+<link rel="stylesheet" href="../css/NIC-Syntax.css" type="text/css" media="screen">
+
+The New Instance Creator (NIC) is a component of the Theos development suite that allows projects (“instances”) to be created quickly based on templates.
+
+A NIC template is a collection of files representing a basic project, before any user customizations have been added.
+
+## Terms and Semantics
+
+Constraint
+- A condition under a which a file, directory or symlink will be created.
+- A file is said to be *constrained* when given a condition.
+
+<span class="required">required</span>
+- The item indicated by this tag must be present.
+
+<span class="optional">optional</span>
+- The item indicated by this tag is optional.
+
+<code>text</code>
+- The text indicated by <code>text</code> is <span class="required">required</span> to be part of the directive and is not to be substituted with any other values.
+
+<code>...</code>
+- The tokens preceding the <code>...</code> may be optionally repeated with the specified delimiter.
+
+## Package Control Data (<code>NIC/control</code>)
+
+Each NIC template <span class="required">requires</span> a control file. The control file contains basic static information about the template.
+
+### Directives
+
+<code><strong>name</strong> "<span class="required">name</span>"</code>
+
+- <span class="required">required</span>
+- Specifies the name of this NIC template.
+
+<code class="optional"><strong>prompt</strong> <span class="required">variable</span> "<span class="required">prompt text</span>" <span class="optional">"default value"</span></code>
+
+- <span class="optional">optional</span>
+- Prompts the user for additional information, which will be stored in *variable*.
+- Optionally supports the inclusion of a default value, which the user can accept by entering nothing.
+- The user is given a chance to override the prompt variable with his or her <code>~/.nicrc</code>.
+
+<code><strong>constrain</strong> "<span class="required">path</span>" to <span class="required">constraint</span></code>
+
+- <span class="optional">optional</span>
+- Constrains the given file, directory or symbolic link *path* to be created only when the *constraint* condition is met.
+
+<code><strong>ignore</strong> <span class="required">built-in variable</span></code>
+
+- <span class="optional">optional</span>
+- Do not prompt for the given *built-in variable*. The following built-in variables are supported:
+    - <code>USER</code>
+	- <code>PACKAGENAME</code>
+
+### Built-in Constraints
+
+<code>package</code>
+- Set by default when the new project is expected to be made into a package. Its converse, <code>!package</code>, can be used to create files only when the project is not being packaged.
+- The NIC templates that ship with Theos use the <code>package</code> constraint to avoid creating unnecessary <code>control</code> files.
+
+<code>link_theos</code>
+- Used in some templates to include an optional link to theos. Set/overridden by <code>link_theos</code> in the user's <code>~/.nicrc</code>.
+- The NIC templates that ship with Theos use this constraint to avoid creating unnecessary <code>theos/</code> symlinks.
+
+### Example <code>NIC/control</code>
+
+<code style="display:block;">
+    <strong>name</strong> <span class="string">"Awesome Template"</span><br>
+    <strong>constrain</strong> <span class="string">"control"</span> <strong>to</strong> <span class="variable">package</span><br>
+    <strong>prompt</strong> <span class="variable">PIES</span> <span class="string">"Number of Pies to create"</span> <span class="string">"10"</span><br>
+</code>
+
+## Package Control Script (<code>NIC/control.pl</code>)
+
+The package control script is an <span class="optional">optional</span> addition to the NIC format.
+
+Control scripts are written in Perl and have access to the current template.
+
+### API
+
+There are various objects available to you via the NIC scripting interface.
+
+#### Public Methods
+
+- <code>print <span class="required">$data</span></code>
+    - *method*
+    - Display information to the user.
+
+- <code>warn <span class="required">$warning</span></code>
+    - *method*
+    - Display a warning.
+
+- <code>error <span class="required">$error</span></code>
+    - *method*
+    - Display an error and abort building the template.
+
+- <code>exit <span class="required">$status_code</span></code>
+    - *method*
+    - Exit the control script. Any status code other than <code>1</code> will abort building the template.
+
+- <code>prompt(<span class="required">$prompt_text</span> <span class="optional">, {default => $default_value}</span>)</code>
+    - *method*
+    - Prompt the user for additional information. The default value is optional. Returns the user's response.
+
+#### NIC
+
+The <code>NIC</code> object represents the current template.
+
+##### Metadata Manipulation
+
+- <code>NIC->name</code>
+    - **read/write**
+    - The name of the current template.
+
+- <code>NIC->variables</code>
+    - **read-only**
+    - A list of the variables currently set on this template.
+
+- <code>NIC->variable(<span class="required">$name</span>)</code>
+    - **read/write**
+    - The value of the named variable. Can be used as a left-hand value, such as in <code>NIC->variable("NAME") = "Value";</code>
+
+- <code class="method">NIC->prompt(<span class="required">$variable</span>, <span class="required">$prompt_text</span> <span class="optional">, {default => $default_value}</span>)</code>
+    - *method*
+    - Prompt the user for additional information, attaching the user's response to the provided NIC variable. The default value is optional. If *$variable* is not specified, <code>NIC->prompt(...)</code> will return the user's response, and will not store it in the template.
+    - The key difference between <code>prompt(...)</code> and <code>NIC->prompt(...)</code> is that the user is given a chance to override the prompt variable with his or her <code>~/.nicrc</code>.
+
+- <code class="method">NIC->setConstraint(<span class="required">$constraint</span>)</code>
+
+- <code class="method">NIC->clearConstraint(<span class="required">$constraint</span>)</code>
+    - *methods*
+    - Set or clear the constraint given by *$constraint*.
+
+##### Files, Directories, and Symbolic Links
+
+- <code>NIC->lookup(<span class="required">$name</span>)</code>
+    - *method*
+    - Find an existing File, Directory or Symbolic Link in the template archive.
+    - Returns the retrieved NICType or <code>undef</code> on failure.
+
+- <code>NIC->mkfile(<span class="required">$name</span> <span class="optional">, $mode</span>)</code>
+    - *method*
+    - Create a new File with the given name and, optionally, mode.
+    - Returns the newly-created File object.
+
+- <code>NIC->mkdir(<span class="required">$name</span> <span class="optional">, $mode</span>)</code>
+    - *method*
+    - Create a new Directory with the given name and, optionally, mode.
+    - Returns the newly-created Directory object.
+
+- <code>NIC->symlink(<span class="required">$target</span>, <span class="required">$destination</span>)</code>
+    - *method*
+    - Create a new Symbolic Link with the given name pointing to the given target.
+    - <code>$target</code> is expected to be an object acquired via <code>NIC->lookup</code>, <code>NIC->mkdir</code>, <code>NIC->mkfile</code>, or <code>NIC->symlink</code>.
+    - <code>$target</code> can also be a string.
+    - Returns the newly-created Symlink object.
+
+#### NICType
+
+NICType objects are the embodiment of template content. Each file, directory or symbolic link is represented by an instance of a NICType subclass.
+
+NICType objects share a few common propeties.
+
+- <code>$nictype->name</code>
+    - **read/write**
+    - The name of the given NICType object (filename, directory, symbolic link name).
+
+- <code>$nictype->mode</code>
+    - **read/write**
+    - The mode of the given NICType object. Defaults to <code>0644</code> for files and <code>0755</code> for directories.
+
+- <code>$nictype->constraints</code>
+    - **read-only**
+    - A list of the constraints currently attached to the given object.
+
+- <code>$nictype->constrain(<span class="required">$constraint</span>)</code>
+    - *method*
+    - Apply the given constraint to this object. Similar to <code>NIC/control</code>'s <code><strong>constrain</strong> ...</code>.
+
+#### <code>File <- NICType</code>
+
+- Represents a file in the template.
+
+- <code>$file->data</code>
+    - **read/write**
+    - The file's data.
+
+#### <code>Directory <- NICType</code>
+
+- Represents a directory in the template.
+- *Contains no additional methods.*
+
+#### <code>Symlink <- NICType</code>
+
+- Represents a symbolic link in the template.
+- <code>$symlink->target</code>
+    - **read/write**
+    - The target of the symbolic link, as either a reference to a <code>NICType</code> object or a string.
+
+### Example <code>NIC/control.pl</code>
+
+<code style="display:block;">
+    <span class="comment"># Retrieve the package name as specified by the user.</span><br>
+    my <span class="variable">$packageName</span> = NIC-><strong>variable</strong>(<span class="string">"PACKAGENAME"</span>);<br>
+    my <span class="variable">$packageDirectory</span> = <span class="variable">$packageName</span>;<br>
+    <br>
+    <span class="comment"># Transform the package name into a package directory, replacing . with / (s!old!new!g acts as a search and replace).</span><br>
+    <span class="variable">$packageDirectory</span> =~ s!\.!/!g;<br>
+    <br>
+    <span class="comment"># Create a new directory entry with the name we just transformed.</span><br>
+    my $directory = NIC-><strong>mkdir</strong>(<span class="variable">$packageDirectory</span>);<br>
+    <br>
+    <span class="comment"># Look up the file "main.m" and set its name to include the new path.</span><br>
+    NIC-><strong>lookup</strong>(<span class="string">"main.m"</span>)-><strong>name</strong> = <span class="variable">$directory</span>-><strong>name</strong> . <span class="string">"/main.m"</span>;
+</code>
+<!-- Modified from http://theos.howett.net/nic/ (CC0) -->

--- a/docs/NIC.md
+++ b/docs/NIC.md
@@ -118,5 +118,3 @@ iphone_tweak.nic.tar
 ```
 
 The predecessor to `.nic.tar` was `.nic`, a plain text file. It was upgraded to the current tar-based format to allow greater fidelity, such as the preservation of file permissions, and inclusion of binary files.
-
-*(To do: The syntax of templates should be discussed here. Unfortunately, DHowett’s documentation on NIC has [disappeared](http://theos.howett.net/nic/) and is not archived on Wayback Machine. The best alternative is to denicify existing templates and see how they work.)*

--- a/docs/dm.pl.md
+++ b/docs/dm.pl.md
@@ -3,12 +3,12 @@ title: dm.pl
 layout: docs
 ---
 
-dm.pl is basic drop-in replacement for `dpkg-deb -b` that allows for the creation of Debian software packages (.deb's).
+dm.pl is a basic drop-in replacement for `dpkg-deb -b` that allows for the creation of Debian software packages (.deb's).
 
 ## Notable features
 
 - Maintains lzma compression support
-    - `dpkg` switched to xz compression and marked lzma as deprecated
+    - `dpkg` switched to xz compression in v1.17.0 and marked lzma as deprecated
 - Is platform independent (i.e., doesn't require `dpkg`)
 
 ## Usage
@@ -38,6 +38,6 @@ Options:
 
 ## Theos usage
 
-dm.pl is provided with Theos and is run with lzma compression at level 1 by default and level 9 when building FOR_RELEASE or FINALPACKAGE.
+dm.pl is provided with Theos and is run, by default, with lzma compression at level 1 for debug builds and level 9 when building FOR_RELEASE or FINALPACKAGE.
 
-Note: the compression type and its level can be modified if desired.
+Note: the compression type and its level can be modified by the user if desired.

--- a/docs/dm.pl.md
+++ b/docs/dm.pl.md
@@ -1,0 +1,43 @@
+---
+title: dm.pl
+layout: docs
+---
+
+dm.pl is basic drop-in replacement for `dpkg-deb -b` that allows for the creation of Debian software packages (.deb's).
+
+## Notable features
+
+- Maintains lzma compression support
+    - `dpkg` switched to xz support and marked lzma as obsolete
+- Is platform independent (i.e., doesn't require `dpkg`)
+
+## Usage
+
+```
+Usage:
+    dm.pl [options] <directory> <package>
+
+Options:
+    -b      This option exists solely for compatibility with dpkg-deb.
+
+    -Z<compression>
+            Specify the package compression type. Valid values are gzip
+            (default), bzip2, lzma, xz and cat (no compression).
+
+    -z<compress-level>
+            Specify the package compression level. Valid values are between
+            0 and 9. Default is 9 for bzip2, 6 for others, and 0 is
+            equivalent to cat. Refer to gzip(1), bzip2(1), xz(1) for
+            explanations of what effect each compression level has.
+
+    --help, -?
+            Print a brief help message and exit.
+
+    --man   Print a manual page and exit.
+```
+
+## Theos usage
+
+dm.pl is provided with Theos and is run with lzma compression at level 1 by default and level 9 when building FOR_RELEASE or FINALPACKAGE.
+
+Note that the compression type and its level can be modified if desired.

--- a/docs/dm.pl.md
+++ b/docs/dm.pl.md
@@ -8,7 +8,7 @@ dm.pl is basic drop-in replacement for `dpkg-deb -b` that allows for the creatio
 ## Notable features
 
 - Maintains lzma compression support
-    - `dpkg` switched to xz support and marked lzma as obsolete
+    - `dpkg` switched to xz compression and marked lzma as deprecated
 - Is platform independent (i.e., doesn't require `dpkg`)
 
 ## Usage
@@ -40,4 +40,4 @@ Options:
 
 dm.pl is provided with Theos and is run with lzma compression at level 1 by default and level 9 when building FOR_RELEASE or FINALPACKAGE.
 
-Note that the compression type and its level can be modified if desired.
+Note: the compression type and its level can be modified if desired.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See title

Does this close any currently open issues?
------------------------------------------
Would close #16 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
- Shot Dustin an email re the nic doc and he gave me permission to port it for use here
- I get a couple of errors when trying to build the docs that may or may not be specific to my setup:
```shell
Liquid Exception: Could not locate the included file 'navigation.html' in any of ["/home/lightmann/doc-test/_includes"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source. in /_layouts/post.html
```
Resolve by removing the commented-out bit from `_layouts/post.html`

```shell
Liquid Exception: Liquid syntax error (line 8): Unknown tag 'when' in vendor/cache/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/locales/en.yml
```
Resolve by adding `vendor` to the `_config.yml` exclude list

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL) 

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
