### PR TITLE
Add gzip

### DIFF
--- a/docs/Installation-iOS.md
+++ b/docs/Installation-iOS.md
@@ -20,7 +20,7 @@ Unless otherwise stated, all of the commands shown in the following instructions
 
 1. Install the following prerequisites<sup>1</sup> as *root*:
 
-		apt-get install bash curl sudo
+		apt-get install bash curl gzip sudo
 
 	<sup>
 	<sup>1</sup> In order to use <i>sudo</i>, your non-root user may need to be added to the sudoers file (/etc/sudoers). See [ArchWiki](https://wiki.archlinux.org/title/Sudo#Example_entries) for more information.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds gzip to the required dependencies for installing theos on iOS.
The Theos installer would error out and not install when gzip wasn't installed.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** iOS 14.2

**Platform:** iOS

**Jailbreak:** Odysseyra1n

**Target Platform:** N/A

**Toolchain Version:** N/A

**SDK Version:** N/A