### PR TITLE
Clarify (un)install items in Commands.md

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -13,8 +13,8 @@ Commands in Theos are implemented as Makefile targets, and are executed by using
 | `make clean` | Clean the build directory so the project is completely rebuilt the next time you run `make`. |
 | `make stage` | Compile source and stage the output into `$THEOS_STAGING_DIR` (by default, `.theos/_/`). This creates the filesystem hierarchy that will be installed on a target device. |
 | `make package` | Compile source, execute staging, and build an output package into `$THEOS_PACKAGE_DIR` (by default, `packages/`). |
-| `make install` | Install the last built package to the device located at `$THEOS_DEVICE_IP:$THEOS_DEVICE_PORT`. If ran on an iOS device without `$THEOS_DEVICE_IP` set, it will install the package locally. |
-| `make uninstall` | Uninstall the current project's package on the device located at `$THEOS_DEVICE_IP:$THEOS_DEVICE_PORT` if said package is installed. If ran on an iOS device without `$THEOS_DEVICE_IP` set, it will uninstall the package locally. |
+| `make install` | Install the last built package to the device located at `$THEOS_DEVICE_IP:$THEOS_DEVICE_PORT`. If ran without `$THEOS_DEVICE_IP` set, it will attempt to install the package locally. |
+| `make uninstall` | Uninstall the current project's package on the device located at `$THEOS_DEVICE_IP:$THEOS_DEVICE_PORT` if said package is installed. If ran without `$THEOS_DEVICE_IP` set, it will attempt to uninstall the package locally. |
 
 You most frequently want to use **`make do`** to build your latest changes, stage and package it up, and install on your configured device. This is a shortcut for `make package install`.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Changes iOS-specific (un)install language to be more generic as [TARGET_INSTALL_REMOTE was fixed](https://github.com/theos/theos/commit/bab33eafd778b76c69a23930bd2378e492a57eea) so packages can be installed locally if the platform supports them 

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
