### PR TITLE
Add more info on rootless.h

### DIFF
--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -49,16 +49,15 @@ Theos supports building for the rootless scheme in a few ways:
     - Courtesy of opa334
 
 
-#### ``rootless.h`` implementation:
+#### `rootless.h` implementation:
 - `ROOT_PATH_NS` for Obj-C strings.
-- ``lROOT_PATH` for C strings.
-- `ROOT_PATH_NS_VAR` Dynamically constructs a file path by appending the provided path component to ```/var/jb```[Obj-C]
+- `ROOT_PATH` for C strings.
 
 `rootless.h` can be used with Obj-C strings with like so:
-```
+
+```objc
 NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
 ```
-`rootless.h` is included with Theos and it can be imported as shown above.
 
 - `THEOS_PACKAGE_SCHEME=rootless` -- a variable to enable a handful of internal changes including:
     - Searching for libraries and frameworks when linking in `$THEOS_LIBRARY_PATH/iphone/rootless` and `$THEOS_VENDOR_LIBRARY_PATH/iphone/rootless`

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -47,7 +47,8 @@ Theos supports building for the rootless scheme in a few ways:
 - Provides [`rootless.h`](https://github.com/theos/headers/blob/master/rootless.h) -- a header that contains convenient macros to easily convert rootful paths to rootless ones in your code at compile-time, assuming you compile for the rootless scheme (see below)
     - `#import <rootless.h>`
     - Courtesy of opa334
-    - 
+
+
 ### ``rootless.h`` implementation
 - ``ROOT_PATH_NS`` for Obj-C strings.
 - ``ROOT_PATH`` for C strings.

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -87,9 +87,7 @@ endif
 - ``ROOT_PATH_C_VAR`` for C string variables, The string returned by this will get freed when your function exits If you want to keep it, use ``strdup``.
 
 ``rootless.h`` can be used with Obj-C strings with like so:
-```ObjC
+```
 NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
 ```
 ``rootless.h`` is included with Theos and it can be imported as shown above.
-
-You can find the code ``rootless.h`` [here](https://gist.github.com/opa334/b14fa4a593bbb79f025cda6113e8b81b) 

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -52,7 +52,7 @@ Theos supports building for the rootless scheme in a few ways:
 #### ``rootless.h`` implementation
 - ``ROOT_PATH_NS`` for Obj-C strings.
 - ``ROOT_PATH`` for C strings.
-- ``ROOT_VAR`` for Obj-C vars.
+- ``ROOT_PATH_NS_VAR`` appends ``/var/jb`` before a path
 
 ``rootless.h`` can be used with Obj-C strings with like so:
 ```

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -50,15 +50,15 @@ Theos supports building for the rootless scheme in a few ways:
 
 
 #### ``rootless.h`` implementation:
-- ``ROOT_PATH_NS`` for Obj-C strings.
-- ``ROOT_PATH`` for C strings.
-- ``ROOT_PATH_NS_VAR`` Dynamically constructs a file path by appending the provided path component to ```/var/jb```[Obj-C]
+- `ROOT_PATH_NS` for Obj-C strings.
+- ``lROOT_PATH` for C strings.
+- `ROOT_PATH_NS_VAR` Dynamically constructs a file path by appending the provided path component to ```/var/jb```[Obj-C]
 
-``rootless.h`` can be used with Obj-C strings with like so:
+`rootless.h` can be used with Obj-C strings with like so:
 ```
 NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
 ```
-``rootless.h`` is included with Theos and it can be imported as shown above.
+`rootless.h` is included with Theos and it can be imported as shown above.
 
 - `THEOS_PACKAGE_SCHEME=rootless` -- a variable to enable a handful of internal changes including:
     - Searching for libraries and frameworks when linking in `$THEOS_LIBRARY_PATH/iphone/rootless` and `$THEOS_VENDOR_LIBRARY_PATH/iphone/rootless`

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -5,7 +5,7 @@ layout: docs
 
 ### Context
 
-Practically all jailbreaks prior to iOS 15 have been 'rootful' as they work on and install files to the (root) system directories (e.g., `/usr`, `/Library`, `/Applications`, etc). Moving forward with iOS 15 and beyond, most if not all jailbreaks will have to be 'rootless' as Apple now prevents writing to the system directories with a protection called [Signed System Volume (SSV)](https://support.apple.com/guide/security/signed-system-volume-security-secd698747c9/web). There are workarounds for this, namely bindFS, but these are less than ideal.
+Practically all jailbreaks prior to iOS 15 have been 'rootful' as they work on and install files to the (root) system directories (e.g., `/usr`, `/Library`, `/Applications`, etc.). Moving forward with iOS 15 and beyond, most if not all jailbreaks will have to be 'rootless' as Apple now prevents writing to the system directories with a protection called [Signed System Volume (SSV)](https://support.apple.com/guide/security/signed-system-volume-security-secd698747c9/web). There are workarounds for this, namely bindFS, but these are less than ideal.
 
 Note that 'rootless' does not imply lack of `root` user permissions, contrary to what its name might suggest.
 
@@ -80,3 +80,16 @@ else
 	TARGET = iphone:clang:latest:7.0
 endif
 ```
+
+### ``rootless.h`` implementation
+- ``ROOT_PATH_NS`` for Obj-C strings.
+- ``ROOT_PATH_C`` for C string literals. 
+- ``ROOT_PATH_C_VAR`` for C string variables, The string returned by this will get freed when your function exits If you want to keep it, use ``strdup``.
+
+``rootless.h`` can be used with Obj-C strings with like so:
+```ObjC
+NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
+```
+``rootless.h`` is included with Theos and it can be imported as shown above.
+
+You can find the code ``rootless.h`` [here](https://gist.github.com/opa334/b14fa4a593bbb79f025cda6113e8b81b) 

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -50,6 +50,7 @@ Theos supports building for the rootless scheme in a few ways:
 
 
 #### `rootless.h` implementation:
+
 - `ROOT_PATH_NS` for Obj-C strings.
 - `ROOT_PATH` for C strings.
 

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -49,7 +49,7 @@ Theos supports building for the rootless scheme in a few ways:
     - Courtesy of opa334
 
 
-### ``rootless.h`` implementation
+#### ``rootless.h`` implementation
 - ``ROOT_PATH_NS`` for Obj-C strings.
 - ``ROOT_PATH`` for C strings.
 - ``ROOT_VAR`` for Obj-C vars.

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -49,10 +49,10 @@ Theos supports building for the rootless scheme in a few ways:
     - Courtesy of opa334
 
 
-#### ``rootless.h`` implementation
+#### ``rootless.h`` implementation:
 - ``ROOT_PATH_NS`` for Obj-C strings.
 - ``ROOT_PATH`` for C strings.
-- ``ROOT_PATH_NS_VAR`` appends ``/var/jb`` before a path
+- ``ROOT_PATH_NS_VAR`` Dynamically constructs a file path by appending the provided path component to ```/var/jb```[Obj-C]
 
 ``rootless.h`` can be used with Obj-C strings with like so:
 ```

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -47,6 +47,17 @@ Theos supports building for the rootless scheme in a few ways:
 - Provides [`rootless.h`](https://github.com/theos/headers/blob/master/rootless.h) -- a header that contains convenient macros to easily convert rootful paths to rootless ones in your code at compile-time, assuming you compile for the rootless scheme (see below)
     - `#import <rootless.h>`
     - Courtesy of opa334
+    - 
+### ``rootless.h`` implementation
+- ``ROOT_PATH_NS`` for Obj-C strings.
+- ``ROOT_PATH`` for C strings.
+- ``ROOT_VAR`` for Obj-C vars.
+
+``rootless.h`` can be used with Obj-C strings with like so:
+```
+NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
+```
+``rootless.h`` is included with Theos and it can be imported as shown above.
 
 - `THEOS_PACKAGE_SCHEME=rootless` -- a variable to enable a handful of internal changes including:
     - Searching for libraries and frameworks when linking in `$THEOS_LIBRARY_PATH/iphone/rootless` and `$THEOS_VENDOR_LIBRARY_PATH/iphone/rootless`
@@ -80,14 +91,3 @@ else
 	TARGET = iphone:clang:latest:7.0
 endif
 ```
-
-### ``rootless.h`` implementation
-- ``ROOT_PATH_NS`` for Obj-C strings.
-- ``ROOT_PATH`` for C strings.
-- ``ROOT_VAR`` for Obj-C vars.
-
-``rootless.h`` can be used with Obj-C strings with like so:
-```
-NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");
-```
-``rootless.h`` is included with Theos and it can be imported as shown above.

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -54,7 +54,7 @@ Theos supports building for the rootless scheme in a few ways:
 - `ROOT_PATH_NS` for Obj-C strings.
 - `ROOT_PATH` for C strings.
 
-`rootless.h` can be used with Obj-C strings with like so:
+`rootless.h` can be used with Obj-C strings like so:
 
 ```objc
 NSString *dylibPath = ROOT_PATH_NS(@"/Library/MobileSubstrate/DynamicLibraries/libFLEX.dylib");

--- a/docs/Rootless.md
+++ b/docs/Rootless.md
@@ -83,8 +83,8 @@ endif
 
 ### ``rootless.h`` implementation
 - ``ROOT_PATH_NS`` for Obj-C strings.
-- ``ROOT_PATH_C`` for C string literals. 
-- ``ROOT_PATH_C_VAR`` for C string variables, The string returned by this will get freed when your function exits If you want to keep it, use ``strdup``.
+- ``ROOT_PATH`` for C strings.
+- ``ROOT_VAR`` for Obj-C vars.
 
 ``rootless.h`` can be used with Obj-C strings with like so:
 ```


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Added more info on `rootless.h`
![rootless](https://github.com/theos/theos.dev/assets/121495559/71237303-5588-442d-8fe9-ba21699e6e1f)

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
Fixed minor grammar error.

Where has this been tested?
---------------------------
Deployed my whole fork on Netlify.
[Demo of this in the Theos website](https://theoswebiste.netlify.app/docs/rootless)
