### PR TITLE
Revert "Merge pull request #61 from theos/dependabot/bundler/nokogiri…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.9.0"
 
 # Needed for macOS ARM
-gem "nokogiri", "~> 1.16.5"
+gem "nokogiri", "~> 1.15.6"
 
 # Needed to unbreak jekyll-assets
 gem "sprockets", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     minitest (5.14.4)
-    nokogiri (1.16.5-x86_64-darwin)
+    nokogiri (1.15.6-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.15.6-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -116,7 +116,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   kramdown-parser-gfm (~> 1.1.0)
-  nokogiri (~> 1.16.5)
+  nokogiri (~> 1.15.6)
   sprockets (~> 3.7)
 
 BUNDLED WITH


### PR DESCRIPTION
…-1.16.5"

This reverts commit ba3044adf08fa11d13b9a9e3a8691828fe397f0f, reversing changes made to ed56814e313b8a87876826ab7def4f5e3e195527.

<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the broken deployment 

Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
```
7:34:14 PM: nokogiri-1.16.5-x86_64-linux requires ruby version < 3.4.dev, >= 3.0, which is
7:34:14 PM: incompatible with the current version, ruby 2.7.2p137
```

Any other comments?
-------------------
- Relevant deployment log: https://app.netlify.com/sites/theos-site/deploys/6642a3551d12500008ec8657 from https://github.com/theos/theos.dev/pull/61
- *Alternatively*, we bump the ruby version we use to > 3 and < 3.4

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
